### PR TITLE
include PATH in cli environment

### DIFF
--- a/src/widgets/cli.tsx
+++ b/src/widgets/cli.tsx
@@ -83,7 +83,7 @@ export class Cli extends BaseWidget {
       allEnvVars = { ...allEnvVars, ...cliEnv };
     }
 
-    allEnvVars = { ...allEnvVars, ...(this.environmentVariables || {}) };
+    allEnvVars = { ...allEnvVars, ...(this.environmentVariables || {}), PATH: process.env.PATH };
 
     commands.push(this.command);
     try {


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix


## Summary of Bug Fix
Since we pass only a subset of environment variables to the child_process, it did not have PATH and therefore could execute any bin scripts.  We do want to limit what the child_process has access to on the environment so rather than passing all of process.env, for now we just explicitly add PATH along with any env vars defined for the CliWidget.

This has the session manager working but the default command will still fail if the task on the cluster does not have procps installed (which is not standard in less bloated docker base images).