### PR TITLE
use bash shell for cli exec

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -87,7 +87,7 @@ export class Cli extends BaseWidget {
     commands.push(this.command);
     try {
       if (shouldRun) {
-        const { stdout, stderr } = await execPromise(commands.join(';'), { env: allEnvVars });
+        const { stdout, stderr } = await execPromise(commands.join(';'), { env: allEnvVars, shell: '/bin/bash' });
         this.commandResult = {
           stdout: stdout.trim(),
           stderr: stderr.trim()


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix

## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
Docs claimed that cli widget runs as bash but used default Bourne shell.

### New Behaviour
_Description of the bug fix and it's impact_
We specify bash as the shell when running child_process.exec

## Other details
This works well for running in docker.  If we ever plan to let users run the console directly in node this can be problematic for windows users unless they run it through GitBash or something similar.  In general though, if we allow use of the node process outside of docker there are many other platform specific things that we would have to take into consideration as well with this being one of the smaller/easier to document ones.