### PR TITLE
markdown docs

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Docs first draft

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+@tinystacks/ops-core-widgets / [Exports](modules.md)
+
+## Overview
+This package contains a list of core Ops Console widgets.
+
+## List of widgets
+|Name|Description|
+|---------|---------|
+|Panel|This widget renders multiple internal widgets in a single direction, either vertical or horizontal.
+|Tabs|This widget renders multiple internal widgets in a tab view. Combine with panel or grid to make robust views.
+|Grid|This widget renders multiple internal widgets in a grid.
+|Markdown|This widget renders markdown.
+|CLI|This widget runs a bash command. The command may be multiple commands separated by ';'. You can also reference scripts that exist in the same directory as your config.
+
+### Panel
+This widget renders multiple internal widgets in a single direction, either vertical or horizontal.
+
+|Parameter|Required|Type|Description|
+|---------|---------|---------|---------|
+|displayName|Yes|string|Display name of widget.
+|children|Yes|array<Widget>|The widgets to render in the panel
+|orientation|No|horizontal or vertical|Direction in which to lay out children widgets. (default: vertical)
+
+### Tabs
+This widget renders multiple internal widgets in a tab view. Combine with panel or grid to make robust views.
+
+|Parameter|Required|Type|Description|
+|---------|---------|---------|---------|
+|displayName|Yes|string|Display name of widget.
+|children|Yes|array<Widget>|The widgets to render in the panel.
+|tabNames|Yes|array<string>|Tab names for each respective tab widget.
+
+### Grid
+This widget renders multiple internal widgets in a grid.
+
+|Parameter|Required|Type|Description|
+|---------|---------|---------|---------|
+|displayName|Yes|string|Display name of widget.
+|children|Yes|array<Widget>|The widgets to render in the panel.
+|columns|No|number|The number of columns to render. (default: 2)
+
+### Markdown
+This widget renders markdown.
+
+|Parameter|Required|Type|Description|
+|---------|---------|---------|---------|
+|displayName|Yes|string|Display name of widget.
+|markdown|Yes|string|The markdown to render.
+
+### CLI
+This widget runs a bash command. The command may be multiple commands separated by ';'. You can also reference scripts that exist in the same directory as your config.
+
+|Parameter|Required|Type|Description|
+|---------|---------|---------|---------|
+|displayName|Yes|string|Display name of widget.
+|environmentVariables|No|map<string,string>|A set of Key-Value pairs that set the environment. <br/>ex.<br/>&nbsp;&nbsp;VAR1: 10<br/>&nbsp;&nbsp;VAR2: 9
+|providers|No|array<Widget>|A list of providers. Providers will only be used if they implement CliEnvironmentProvider. Each environment variable from compatible providers will be exported to the shell.
+|command|Yes|string|A semi-colon seperated set of commands.
+|runOnStart|No|boolean|Whether or not to run the command when the dashboard and widget are first rendered. If disabled, the command will not run until the run button is pressed. (default: false)

--- a/docs/classes/Cli.md
+++ b/docs/classes/Cli.md
@@ -1,0 +1,347 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / Cli
+
+# Class: Cli
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`Cli`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Cli.md#constructor)
+
+### Properties
+
+- [childrenIds](Cli.md#childrenids)
+- [command](Cli.md#command)
+- [commandResult](Cli.md#commandresult)
+- [description](Cli.md#description)
+- [displayName](Cli.md#displayname)
+- [displayOptions](Cli.md#displayoptions)
+- [environmentVariables](Cli.md#environmentvariables)
+- [hasRun](Cli.md#hasrun)
+- [id](Cli.md#id)
+- [providerIds](Cli.md#providerids)
+- [runOnStart](Cli.md#runonstart)
+- [type](Cli.md#type)
+- [type](Cli.md#type-1)
+
+### Methods
+
+- [envVarMapper](Cli.md#envvarmapper)
+- [getData](Cli.md#getdata)
+- [render](Cli.md#render)
+- [toJson](Cli.md#tojson)
+- [fromJson](Cli.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new Cli**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Cli`](../modules/OpsTypes.md#cli) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/cli.tsx:21](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L21)
+
+## Properties
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### command
+
+• **command**: `string`
+
+#### Defined in
+
+[src/cli.tsx:15](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L15)
+
+___
+
+### commandResult
+
+• **commandResult**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `stderr` | `string` |
+| `stdout` | `string` |
+
+#### Defined in
+
+[src/cli.tsx:17](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L17)
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### environmentVariables
+
+• **environmentVariables**: `Object`
+
+#### Index signature
+
+▪ [key: `string`]: `string`
+
+#### Defined in
+
+[src/cli.tsx:19](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L19)
+
+___
+
+### hasRun
+
+• **hasRun**: `boolean`
+
+#### Defined in
+
+[src/cli.tsx:18](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L18)
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### runOnStart
+
+• **runOnStart**: `boolean`
+
+#### Defined in
+
+[src/cli.tsx:16](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L16)
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+___
+
+### type
+
+▪ `Static` **type**: `string` = `'Cli'`
+
+#### Defined in
+
+[src/cli.tsx:14](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L14)
+
+## Methods
+
+### envVarMapper
+
+▸ **envVarMapper**(`envVars`): `string`[]
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `envVars` | `Object` |
+
+#### Returns
+
+`string`[]
+
+#### Defined in
+
+[src/cli.tsx:37](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L37)
+
+___
+
+### getData
+
+▸ **getData**(`providers?`, `overrides?`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `providers?` | `BaseProvider`[] |
+| `overrides?` | `CliOverrides` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/cli.tsx:52](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L52)
+
+___
+
+### render
+
+▸ **render**(`_children?`, `overridesCallback?`): `Element`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_children?` | `any` |
+| `overridesCallback?` | (`overrides`: `CliOverrides`) => `void` |
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/cli.tsx:101](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L101)
+
+___
+
+### toJson
+
+▸ **toJson**(): [`Cli`](../modules/OpsTypes.md#cli)
+
+#### Returns
+
+[`Cli`](../modules/OpsTypes.md#cli)
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/cli.tsx:41](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L41)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`Cli`](Cli.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | [`Cli`](../modules/OpsTypes.md#cli) |
+
+#### Returns
+
+[`Cli`](Cli.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/cli.tsx:33](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/cli.tsx#L33)

--- a/docs/classes/Github.md
+++ b/docs/classes/Github.md
@@ -1,0 +1,343 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / Github
+
+# Class: Github
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`Github`**
+
+## Implements
+
+- [`Github`](../modules/OpsTypes.md#github)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Github.md#constructor)
+
+### Properties
+
+- [actions](Github.md#actions)
+- [childrenIds](Github.md#childrenids)
+- [description](Github.md#description)
+- [displayName](Github.md#displayname)
+- [displayOptions](Github.md#displayoptions)
+- [host](Github.md#host)
+- [id](Github.md#id)
+- [organization](Github.md#organization)
+- [providerIds](Github.md#providerids)
+- [repository](Github.md#repository)
+- [type](Github.md#type)
+
+### Methods
+
+- [getData](Github.md#getdata)
+- [render](Github.md#render)
+- [toJson](Github.md#tojson)
+- [fromJson](Github.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new Github**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Github`](../modules/OpsTypes.md#github) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/github.tsx:37](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L37)
+
+## Properties
+
+### actions
+
+• `Optional` **actions**: [`GithubAction`](../modules/OpsTypes.md#githubaction)[]
+
+#### Implementation of
+
+GithubType.actions
+
+#### Defined in
+
+[src/github.tsx:35](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L35)
+
+___
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Implementation of
+
+GithubType.childrenIds
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Implementation of
+
+GithubType.description
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Implementation of
+
+GithubType.displayName
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Implementation of
+
+GithubType.displayOptions
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### host
+
+• `Optional` **host**: `string`
+
+#### Implementation of
+
+GithubType.host
+
+#### Defined in
+
+[src/github.tsx:32](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L32)
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Implementation of
+
+GithubType.id
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### organization
+
+• **organization**: `string`
+
+#### Implementation of
+
+GithubType.organization
+
+#### Defined in
+
+[src/github.tsx:33](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L33)
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Implementation of
+
+GithubType.providerIds
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### repository
+
+• **repository**: `string`
+
+#### Implementation of
+
+GithubType.repository
+
+#### Defined in
+
+[src/github.tsx:34](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L34)
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Implementation of
+
+GithubType.type
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+## Methods
+
+### getData
+
+▸ **getData**(`providers?`, `overrides?`, `_parameters?`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `providers?` | `BaseProvider`[] |
+| `overrides` | `GithubOverrides` |
+| `_parameters?` | `OtherProperties` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/github.tsx:65](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L65)
+
+___
+
+### render
+
+▸ **render**(`_children?`, `_overridesCallback?`): `Element`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_children?` | `Widget` & { `renderedElement`: `Element`  }[] |
+| `_overridesCallback?` | (`overrides`: `any`) => `void` |
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/github.tsx:126](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L126)
+
+___
+
+### toJson
+
+▸ **toJson**(): [`Github`](../modules/OpsTypes.md#github)
+
+#### Returns
+
+[`Github`](../modules/OpsTypes.md#github)
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/github.tsx:55](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L55)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`, `_dependencySource?`): [`Github`](Github.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | [`Github`](../modules/OpsTypes.md#github) |
+| `_dependencySource?` | `string` |
+
+#### Returns
+
+[`Github`](Github.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/github.tsx:51](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/github.tsx#L51)

--- a/docs/classes/GithubCredentialsProvider.md
+++ b/docs/classes/GithubCredentialsProvider.md
@@ -1,0 +1,216 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / GithubCredentialsProvider
+
+# Class: GithubCredentialsProvider
+
+## Hierarchy
+
+- `BaseProvider`
+
+  ↳ **`GithubCredentialsProvider`**
+
+## Implements
+
+- [`CliEnvironmentProvider`](../interfaces/CliEnvironmentProvider.md)
+- [`CredentialsProvider`](../interfaces/CredentialsProvider.md)
+- [`GithubCredentialsProvider`](../modules/OpsTypes.md#githubcredentialsprovider)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](GithubCredentialsProvider.md#constructor)
+
+### Properties
+
+- [credentials](GithubCredentialsProvider.md#credentials)
+- [host](GithubCredentialsProvider.md#host)
+- [id](GithubCredentialsProvider.md#id)
+- [type](GithubCredentialsProvider.md#type)
+- [type](GithubCredentialsProvider.md#type-1)
+
+### Methods
+
+- [getCliEnvironment](GithubCredentialsProvider.md#getclienvironment)
+- [getCredentials](GithubCredentialsProvider.md#getcredentials)
+- [toJson](GithubCredentialsProvider.md#tojson)
+- [fromJson](GithubCredentialsProvider.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new GithubCredentialsProvider**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`GithubCredentialsProvider`](../modules/OpsTypes.md#githubcredentialsprovider) |
+
+#### Overrides
+
+BaseProvider.constructor
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:16](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L16)
+
+## Properties
+
+### credentials
+
+• **credentials**: [`GithubCredentials`](../modules/OpsTypes.md#githubcredentials)
+
+#### Implementation of
+
+GithubCredentialsProviderType.credentials
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:13](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L13)
+
+___
+
+### host
+
+• `Optional` **host**: `string`
+
+#### Implementation of
+
+GithubCredentialsProviderType.host
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:14](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L14)
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Implementation of
+
+[CredentialsProvider](../interfaces/CredentialsProvider.md).[id](../interfaces/CredentialsProvider.md#id)
+
+#### Inherited from
+
+BaseProvider.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-provider.d.ts:3
+
+___
+
+### type
+
+• **type**: `string`
+
+This describes the type of the provider
+
+#### Implementation of
+
+[CredentialsProvider](../interfaces/CredentialsProvider.md).[type](../interfaces/CredentialsProvider.md#type)
+
+#### Inherited from
+
+BaseProvider.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-provider.d.ts:4
+
+___
+
+### type
+
+▪ `Static` **type**: `string` = `'GithubCredentialsProvider'`
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:12](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L12)
+
+## Methods
+
+### getCliEnvironment
+
+▸ **getCliEnvironment**(`envVars?`): `OtherProperties`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `envVars` | `OtherProperties` |
+
+#### Returns
+
+`OtherProperties`
+
+#### Implementation of
+
+[CliEnvironmentProvider](../interfaces/CliEnvironmentProvider.md).[getCliEnvironment](../interfaces/CliEnvironmentProvider.md#getclienvironment)
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:33](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L33)
+
+___
+
+### getCredentials
+
+▸ **getCredentials**(): [`GithubCredentials`](../modules/OpsTypes.md#githubcredentials)
+
+#### Returns
+
+[`GithubCredentials`](../modules/OpsTypes.md#githubcredentials)
+
+#### Implementation of
+
+[CredentialsProvider](../interfaces/CredentialsProvider.md).[getCredentials](../interfaces/CredentialsProvider.md#getcredentials)
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:29](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L29)
+
+___
+
+### toJson
+
+▸ **toJson**(): `Provider`
+
+#### Returns
+
+`Provider`
+
+#### Inherited from
+
+BaseProvider.toJson
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-provider.d.ts:7
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`GithubCredentialsProvider`](GithubCredentialsProvider.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | [`GithubCredentialsProvider`](../modules/OpsTypes.md#githubcredentialsprovider) |
+
+#### Returns
+
+[`GithubCredentialsProvider`](GithubCredentialsProvider.md)
+
+#### Overrides
+
+BaseProvider.fromJson
+
+#### Defined in
+
+[src/providers/github-credentials-provider.ts:25](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/github-credentials-provider.ts#L25)

--- a/docs/classes/Grid.md
+++ b/docs/classes/Grid.md
@@ -1,0 +1,266 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / Grid
+
+# Class: Grid
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`Grid`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Grid.md#constructor)
+
+### Properties
+
+- [childrenIds](Grid.md#childrenids)
+- [columns](Grid.md#columns)
+- [description](Grid.md#description)
+- [displayName](Grid.md#displayname)
+- [displayOptions](Grid.md#displayoptions)
+- [id](Grid.md#id)
+- [providerIds](Grid.md#providerids)
+- [type](Grid.md#type)
+
+### Methods
+
+- [getData](Grid.md#getdata)
+- [render](Grid.md#render)
+- [toJson](Grid.md#tojson)
+- [fromJson](Grid.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new Grid**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Grid`](../modules/OpsTypes.md#grid) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/grid.tsx:10](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/grid.tsx#L10)
+
+## Properties
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### columns
+
+• **columns**: `number`
+
+#### Defined in
+
+[src/grid.tsx:9](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/grid.tsx#L9)
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+## Methods
+
+### getData
+
+▸ **getData**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/grid.tsx:26](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/grid.tsx#L26)
+
+___
+
+### render
+
+▸ **render**(`children?`): `Element`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `children?` | `Widget` & { `renderedElement`: `Element`  }[] |
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/grid.tsx:27](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/grid.tsx#L27)
+
+___
+
+### toJson
+
+▸ **toJson**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `additionalProperties?` | `any` | - |
+| `childrenIds?` | `string`[] | - |
+| `columns` | `number` | - |
+| `description?` | `string` | - |
+| `displayName` | `string` | A human-readable display name, usually used to title a widget |
+| `displayOptions?` | { `showDescription?`: `boolean` ; `showDisplayName?`: `boolean`  } | - |
+| `displayOptions.showDescription?` | `boolean` | Whether to show the description |
+| `displayOptions.showDisplayName?` | `boolean` | Whether to show the display name |
+| `id` | `string` | Unique Id for this widget. |
+| `providerIds?` | `string`[] | - |
+| `type` | `string` | This describes how this widget should be rendered. The "type" should be equivalent to the Object definition's name of the widget you are trying to render. |
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/grid.tsx:19](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/grid.tsx#L19)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`Grid`](Grid.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | `Widget` |
+
+#### Returns
+
+[`Grid`](Grid.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/grid.tsx:15](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/grid.tsx#L15)

--- a/docs/classes/JsonFilter.md
+++ b/docs/classes/JsonFilter.md
@@ -1,0 +1,283 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / JsonFilter
+
+# Class: JsonFilter
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`JsonFilter`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](JsonFilter.md#constructor)
+
+### Properties
+
+- [childrenIds](JsonFilter.md#childrenids)
+- [description](JsonFilter.md#description)
+- [displayName](JsonFilter.md#displayname)
+- [displayOptions](JsonFilter.md#displayoptions)
+- [filteredJson](JsonFilter.md#filteredjson)
+- [id](JsonFilter.md#id)
+- [jsonObject](JsonFilter.md#jsonobject)
+- [paths](JsonFilter.md#paths)
+- [providerIds](JsonFilter.md#providerids)
+- [type](JsonFilter.md#type)
+- [type](JsonFilter.md#type-1)
+
+### Methods
+
+- [getData](JsonFilter.md#getdata)
+- [render](JsonFilter.md#render)
+- [toJson](JsonFilter.md#tojson)
+- [fromJson](JsonFilter.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new JsonFilter**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`JsonFilter`](../modules/OpsTypes.md#jsonfilter) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/json-filter.tsx:21](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L21)
+
+## Properties
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### filteredJson
+
+• **filteredJson**: { `json`: `string` ; `pathDisplayName`: `string`  }[]
+
+#### Defined in
+
+[src/json-filter.tsx:15](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L15)
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### jsonObject
+
+• **jsonObject**: `Object`
+
+#### Index signature
+
+▪ [key: `string`]: `any`
+
+#### Defined in
+
+[src/json-filter.tsx:10](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L10)
+
+___
+
+### paths
+
+• **paths**: { `path`: `string` ; `pathDisplayName`: `string`  }[]
+
+#### Defined in
+
+[src/json-filter.tsx:11](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L11)
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+___
+
+### type
+
+▪ `Static` **type**: `string` = `'JsonFilter'`
+
+#### Defined in
+
+[src/json-filter.tsx:9](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L9)
+
+## Methods
+
+### getData
+
+▸ **getData**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/json-filter.tsx:43](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L43)
+
+___
+
+### render
+
+▸ **render**(): `Element`
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/json-filter.tsx:67](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L67)
+
+___
+
+### toJson
+
+▸ **toJson**(): [`JsonFilter`](../modules/OpsTypes.md#jsonfilter)
+
+#### Returns
+
+[`JsonFilter`](../modules/OpsTypes.md#jsonfilter)
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/json-filter.tsx:33](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L33)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`JsonFilter`](JsonFilter.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | [`JsonFilter`](../modules/OpsTypes.md#jsonfilter) |
+
+#### Returns
+
+[`JsonFilter`](JsonFilter.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/json-filter.tsx:28](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/json-filter.tsx#L28)

--- a/docs/classes/Markdown.md
+++ b/docs/classes/Markdown.md
@@ -1,0 +1,246 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / Markdown
+
+# Class: Markdown
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`Markdown`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Markdown.md#constructor)
+
+### Properties
+
+- [childrenIds](Markdown.md#childrenids)
+- [description](Markdown.md#description)
+- [displayName](Markdown.md#displayname)
+- [displayOptions](Markdown.md#displayoptions)
+- [id](Markdown.md#id)
+- [markdown](Markdown.md#markdown)
+- [providerIds](Markdown.md#providerids)
+- [type](Markdown.md#type)
+
+### Methods
+
+- [getData](Markdown.md#getdata)
+- [render](Markdown.md#render)
+- [toJson](Markdown.md#tojson)
+- [fromJson](Markdown.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new Markdown**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Markdown`](../modules/OpsTypes.md#markdown) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/markdown.tsx:11](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/markdown.tsx#L11)
+
+## Properties
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### markdown
+
+• **markdown**: `string`
+
+#### Defined in
+
+[src/markdown.tsx:9](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/markdown.tsx#L9)
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+## Methods
+
+### getData
+
+▸ **getData**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/markdown.tsx:24](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/markdown.tsx#L24)
+
+___
+
+### render
+
+▸ **render**(): `Element`
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/markdown.tsx:26](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/markdown.tsx#L26)
+
+___
+
+### toJson
+
+▸ **toJson**(): `any`
+
+#### Returns
+
+`any`
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/markdown.tsx:20](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/markdown.tsx#L20)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`Markdown`](Markdown.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | [`Markdown`](../modules/OpsTypes.md#markdown) |
+
+#### Returns
+
+[`Markdown`](Markdown.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/markdown.tsx:16](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/markdown.tsx#L16)

--- a/docs/classes/Panel.md
+++ b/docs/classes/Panel.md
@@ -1,0 +1,266 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / Panel
+
+# Class: Panel
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`Panel`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Panel.md#constructor)
+
+### Properties
+
+- [childrenIds](Panel.md#childrenids)
+- [description](Panel.md#description)
+- [displayName](Panel.md#displayname)
+- [displayOptions](Panel.md#displayoptions)
+- [id](Panel.md#id)
+- [orientation](Panel.md#orientation)
+- [providerIds](Panel.md#providerids)
+- [type](Panel.md#type)
+
+### Methods
+
+- [getData](Panel.md#getdata)
+- [render](Panel.md#render)
+- [toJson](Panel.md#tojson)
+- [fromJson](Panel.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new Panel**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Panel`](../modules/OpsTypes.md#panel) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/panel.tsx:10](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/panel.tsx#L10)
+
+## Properties
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### orientation
+
+• **orientation**: `string`
+
+#### Defined in
+
+[src/panel.tsx:9](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/panel.tsx#L9)
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+## Methods
+
+### getData
+
+▸ **getData**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/panel.tsx:26](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/panel.tsx#L26)
+
+___
+
+### render
+
+▸ **render**(`children?`): `Element`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `children?` | `Widget` & { `renderedElement`: `Element`  }[] |
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/panel.tsx:27](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/panel.tsx#L27)
+
+___
+
+### toJson
+
+▸ **toJson**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `additionalProperties?` | `any` | - |
+| `childrenIds?` | `string`[] | - |
+| `description?` | `string` | - |
+| `displayName` | `string` | A human-readable display name, usually used to title a widget |
+| `displayOptions?` | { `showDescription?`: `boolean` ; `showDisplayName?`: `boolean`  } | - |
+| `displayOptions.showDescription?` | `boolean` | Whether to show the description |
+| `displayOptions.showDisplayName?` | `boolean` | Whether to show the display name |
+| `id` | `string` | Unique Id for this widget. |
+| `orientation` | `string` | - |
+| `providerIds?` | `string`[] | - |
+| `type` | `string` | This describes how this widget should be rendered. The "type" should be equivalent to the Object definition's name of the widget you are trying to render. |
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/panel.tsx:19](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/panel.tsx#L19)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`Panel`](Panel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | `Widget` |
+
+#### Returns
+
+[`Panel`](Panel.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/panel.tsx:15](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/panel.tsx#L15)

--- a/docs/classes/Tabs.md
+++ b/docs/classes/Tabs.md
@@ -1,0 +1,252 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / Tabs
+
+# Class: Tabs
+
+## Hierarchy
+
+- `BaseWidget`
+
+  ↳ **`Tabs`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Tabs.md#constructor)
+
+### Properties
+
+- [childrenIds](Tabs.md#childrenids)
+- [description](Tabs.md#description)
+- [displayName](Tabs.md#displayname)
+- [displayOptions](Tabs.md#displayoptions)
+- [id](Tabs.md#id)
+- [providerIds](Tabs.md#providerids)
+- [tabNames](Tabs.md#tabnames)
+- [type](Tabs.md#type)
+
+### Methods
+
+- [getData](Tabs.md#getdata)
+- [render](Tabs.md#render)
+- [toJson](Tabs.md#tojson)
+- [fromJson](Tabs.md#fromjson)
+
+## Constructors
+
+### constructor
+
+• **new Tabs**(`props`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Tabs`](../modules/OpsTypes.md#tabs) |
+
+#### Overrides
+
+BaseWidget.constructor
+
+#### Defined in
+
+[src/tabs.tsx:13](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/tabs.tsx#L13)
+
+## Properties
+
+### childrenIds
+
+• `Optional` **childrenIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.childrenIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:11
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Inherited from
+
+BaseWidget.description
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:12
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Inherited from
+
+BaseWidget.displayName
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:8
+
+___
+
+### displayOptions
+
+• `Optional` **displayOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `showDescription?` | `boolean` | Whether to show the description |
+| `showDisplayName?` | `boolean` | Whether to show the display name |
+
+#### Inherited from
+
+BaseWidget.displayOptions
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:9
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+BaseWidget.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:6
+
+___
+
+### providerIds
+
+• `Optional` **providerIds**: `string`[]
+
+#### Inherited from
+
+BaseWidget.providerIds
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:10
+
+___
+
+### tabNames
+
+• **tabNames**: `string`[]
+
+#### Defined in
+
+[src/tabs.tsx:12](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/tabs.tsx#L12)
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Inherited from
+
+BaseWidget.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-core/dist/base-widget.d.ts:7
+
+## Methods
+
+### getData
+
+▸ **getData**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+BaseWidget.getData
+
+#### Defined in
+
+[src/tabs.tsx:26](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/tabs.tsx#L26)
+
+___
+
+### render
+
+▸ **render**(`children?`): `Element`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `children?` | `Widget` & { `renderedElement`: `Element`  }[] |
+
+#### Returns
+
+`Element`
+
+#### Overrides
+
+BaseWidget.render
+
+#### Defined in
+
+[src/tabs.tsx:28](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/tabs.tsx#L28)
+
+___
+
+### toJson
+
+▸ **toJson**(): [`Tabs`](../modules/OpsTypes.md#tabs)
+
+#### Returns
+
+[`Tabs`](../modules/OpsTypes.md#tabs)
+
+#### Overrides
+
+BaseWidget.toJson
+
+#### Defined in
+
+[src/tabs.tsx:22](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/tabs.tsx#L22)
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**(`object`): [`Tabs`](Tabs.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `object` | `Widget` |
+
+#### Returns
+
+[`Tabs`](Tabs.md)
+
+#### Overrides
+
+BaseWidget.fromJson
+
+#### Defined in
+
+[src/tabs.tsx:18](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/tabs.tsx#L18)

--- a/docs/interfaces/CliEnvironmentProvider.md
+++ b/docs/interfaces/CliEnvironmentProvider.md
@@ -1,0 +1,74 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / CliEnvironmentProvider
+
+# Interface: CliEnvironmentProvider
+
+## Hierarchy
+
+- `Provider`
+
+  ↳ **`CliEnvironmentProvider`**
+
+## Implemented by
+
+- [`GithubCredentialsProvider`](../classes/GithubCredentialsProvider.md)
+
+## Table of contents
+
+### Properties
+
+- [id](CliEnvironmentProvider.md#id)
+- [type](CliEnvironmentProvider.md#type)
+
+### Methods
+
+- [getCliEnvironment](CliEnvironmentProvider.md#getclienvironment)
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+Provider.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-model/dist/models/Provider.d.ts:2
+
+___
+
+### type
+
+• **type**: `string`
+
+This describes the type of the provider
+
+#### Inherited from
+
+Provider.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-model/dist/models/Provider.d.ts:6
+
+## Methods
+
+### getCliEnvironment
+
+▸ **getCliEnvironment**(`...args`): { `[key: string]`: `string`;  } \| `Promise`<{ `[key: string]`: `string`;  }\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any` |
+
+#### Returns
+
+{ `[key: string]`: `string`;  } \| `Promise`<{ `[key: string]`: `string`;  }\>
+
+#### Defined in
+
+[src/providers/cli-environment-provider.ts:4](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/cli-environment-provider.ts#L4)

--- a/docs/interfaces/CredentialsProvider.md
+++ b/docs/interfaces/CredentialsProvider.md
@@ -1,0 +1,74 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / CredentialsProvider
+
+# Interface: CredentialsProvider
+
+## Hierarchy
+
+- `Provider`
+
+  ↳ **`CredentialsProvider`**
+
+## Implemented by
+
+- [`GithubCredentialsProvider`](../classes/GithubCredentialsProvider.md)
+
+## Table of contents
+
+### Properties
+
+- [id](CredentialsProvider.md#id)
+- [type](CredentialsProvider.md#type)
+
+### Methods
+
+- [getCredentials](CredentialsProvider.md#getcredentials)
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+#### Inherited from
+
+Provider.id
+
+#### Defined in
+
+node_modules/@tinystacks/ops-model/dist/models/Provider.d.ts:2
+
+___
+
+### type
+
+• **type**: `string`
+
+This describes the type of the provider
+
+#### Inherited from
+
+Provider.type
+
+#### Defined in
+
+node_modules/@tinystacks/ops-model/dist/models/Provider.d.ts:6
+
+## Methods
+
+### getCredentials
+
+▸ **getCredentials**(`...args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any` |
+
+#### Returns
+
+`any`
+
+#### Defined in
+
+[src/providers/credentials-provider.ts:4](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/providers/credentials-provider.ts#L4)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,25 @@
+[@tinystacks/ops-core-widgets](README.md) / Exports
+
+# @tinystacks/ops-core-widgets
+
+## Table of contents
+
+### Namespaces
+
+- [OpsTypes](modules/OpsTypes.md)
+
+### Classes
+
+- [Cli](classes/Cli.md)
+- [Github](classes/Github.md)
+- [GithubCredentialsProvider](classes/GithubCredentialsProvider.md)
+- [Grid](classes/Grid.md)
+- [JsonFilter](classes/JsonFilter.md)
+- [Markdown](classes/Markdown.md)
+- [Panel](classes/Panel.md)
+- [Tabs](classes/Tabs.md)
+
+### Interfaces
+
+- [CliEnvironmentProvider](interfaces/CliEnvironmentProvider.md)
+- [CredentialsProvider](interfaces/CredentialsProvider.md)

--- a/docs/modules/OpsTypes.md
+++ b/docs/modules/OpsTypes.md
@@ -1,0 +1,134 @@
+[@tinystacks/ops-core-widgets](../README.md) / [Exports](../modules.md) / OpsTypes
+
+# Namespace: OpsTypes
+
+## Table of contents
+
+### Type Aliases
+
+- [Cli](OpsTypes.md#cli)
+- [Github](OpsTypes.md#github)
+- [GithubAction](OpsTypes.md#githubaction)
+- [GithubCredentials](OpsTypes.md#githubcredentials)
+- [GithubCredentialsProvider](OpsTypes.md#githubcredentialsprovider)
+- [Grid](OpsTypes.md#grid)
+- [JsonFilter](OpsTypes.md#jsonfilter)
+- [Markdown](OpsTypes.md#markdown)
+- [Panel](OpsTypes.md#panel)
+- [Tabs](OpsTypes.md#tabs)
+
+## Type Aliases
+
+### Cli
+
+Ƭ **Cli**: `Widget` & { `command`: `string` ; `commandResult?`: { `stderr`: `string` ; `stdout`: `string`  } ; `environmentVariables?`: { `[key: string]`: `string`;  } ; `hasRun?`: `boolean` ; `runOnStart?`: `boolean`  }
+
+#### Defined in
+
+[src/ops-types.ts:15](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L15)
+
+___
+
+### Github
+
+Ƭ **Github**: `Widget` & { `actions?`: [`GithubAction`](OpsTypes.md#githubaction)[] ; `host?`: `string` ; `organization`: `string` ; `repository`: `string`  }
+
+#### Defined in
+
+[src/ops-types.ts:31](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L31)
+
+___
+
+### GithubAction
+
+Ƭ **GithubAction**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `lastExecuted` | `Date` |
+| `name` | `string` |
+| `status` | `string` |
+| `trigger` | `string` |
+| `url` | `string` |
+
+#### Defined in
+
+[src/ops-types.ts:23](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L23)
+
+___
+
+### GithubCredentials
+
+Ƭ **GithubCredentials**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `token` | `string` |
+
+#### Defined in
+
+[src/ops-types.ts:3](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L3)
+
+___
+
+### GithubCredentialsProvider
+
+Ƭ **GithubCredentialsProvider**: `Provider` & { `credentials`: [`GithubCredentials`](OpsTypes.md#githubcredentials) ; `host?`: `string`  }
+
+#### Defined in
+
+[src/ops-types.ts:7](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L7)
+
+___
+
+### Grid
+
+Ƭ **Grid**: `Widget` & { `columns?`: `number`  }
+
+#### Defined in
+
+[src/ops-types.ts:38](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L38)
+
+___
+
+### JsonFilter
+
+Ƭ **JsonFilter**: `Widget` & { `filteredJson?`: { `json`: `any` ; `pathDisplayName`: `string`  }[] ; `jsonObject`: { `[key: string]`: `any`;  } ; `paths`: { `path`: `string` ; `pathDisplayName`: `string`  }[]  }
+
+#### Defined in
+
+[src/ops-types.ts:40](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L40)
+
+___
+
+### Markdown
+
+Ƭ **Markdown**: `Widget` & { `markdown`: `string`  }
+
+#### Defined in
+
+[src/ops-types.ts:52](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L52)
+
+___
+
+### Panel
+
+Ƭ **Panel**: `Widget` & { `orientation?`: ``"horizontal"`` \| ``"vertical"``  }
+
+#### Defined in
+
+[src/ops-types.ts:54](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L54)
+
+___
+
+### Tabs
+
+Ƭ **Tabs**: `Widget` & { `tabNames?`: `string`[]  }
+
+#### Defined in
+
+[src/ops-types.ts:56](https://github.com/tinystacks/ops-core-widgets/blob/cdfd6a3/src/ops-types.ts#L56)

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,8 @@
         "react-dom": "^18.2.0",
         "ts-jest": "^29.0.5",
         "ts-jest-resolver": "^2.0.0",
+        "typedoc": "^0.24.8",
+        "typedoc-plugin-markdown": "^3.15.3",
         "typescript": "^4.9.5",
         "typescript-json-schema": "^0.57.0"
       },
@@ -4170,6 +4172,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -9220,6 +9228,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -9343,6 +9357,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -9374,6 +9394,18 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -11152,6 +11184,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -11798,6 +11842,63 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.3.tgz",
+      "integrity": "sha512-idntFYu3vfaY3eaD+w9DeRd0PmNGqGuNLKihPU9poxFGnATJYGn9dPtEhn2QrTdishFMg7jPXAhos+2T6YCWRQ==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.24.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -12147,6 +12248,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
@@ -15714,6 +15827,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -19442,6 +19561,12 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -19545,6 +19670,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -19574,6 +19705,12 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true
     },
     "mdast-util-definitions": {
       "version": "5.1.2",
@@ -20741,6 +20878,18 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "dev": true,
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -21220,6 +21369,47 @@
         "is-typed-array": "^1.1.9"
       }
     },
+    "typedoc": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.3.tgz",
+      "integrity": "sha512-idntFYu3vfaY3eaD+w9DeRd0PmNGqGuNLKihPU9poxFGnATJYGn9dPtEhn2QrTdishFMg7jPXAhos+2T6YCWRQ==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
+      }
+    },
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -21462,6 +21652,18 @@
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/tinystacks/ops-core-widgets.git"
   },
   "scripts": {
-    "build": "tsc && npm run types",
-    "clean": "rm -rf ./dist || true; rm *.tgz || true; rm -rf ./build;",
+    "build": "tsc && npm run types && npm run docs",
+    "clean": "rm -rf ./dist || true; rm -rf ./docs || true; rm *.tgz || true; rm -rf ./build;",
     "clean-build": "npm run clean; npm run build",
     "hard-clean": "npm run clean; rm -rf node_modules; rm package-lock.json",
     "install-remote": "npm i --@tinystacks:registry=https://registry.npmjs.org",
@@ -31,7 +31,8 @@
     "test-file-cov": "NODE_OPTIONS=--experimental-vm-modules npx jest ./test/filter.test.tsx --coverage",
     "view-test-cov": "NODE_OPTIONS=--experimental-vm-modules npx jest --coverage || true && open coverage/lcov-report/index.html",
     "prepare": "husky install",
-    "types": "npx typescript-json-schema './src/ops-types.ts' '*' --out ./dist/ops-types.json --required --esModuleInterop"
+    "types": "npx typescript-json-schema './src/ops-types.ts' '*' --out ./dist/ops-types.json --required --esModuleInterop",
+    "docs": "npx typedoc src/index.ts"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
@@ -61,6 +62,8 @@
     "react-dom": "^18.2.0",
     "ts-jest": "^29.0.5",
     "ts-jest-resolver": "^2.0.0",
+    "typedoc": "^0.24.8",
+    "typedoc-plugin-markdown": "^3.15.3",
     "typescript": "^4.9.5",
     "typescript-json-schema": "^0.57.0"
   },

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "plugin": [
+    "typedoc-plugin-markdown"
+  ]
+}


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Patch

## Link to Notion Task or Github Issue
[Widget docs props representation (typedocs or mkdocs or openapi)](https://www.notion.so/tinystacks/Goals-07ccd37a0c9d4bd5bad6fc3dbbe13995)

## Summary of Patch
Mirror of https://github.com/tinystacks/ops-core-widgets/pull/36 but with Markdown output instead of HTML.