### PR TITLE
Types -> Interfaces

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- types -> interfaces for docs generation

--- a/src/ops-types.ts
+++ b/src/ops-types.ts
@@ -1,43 +1,43 @@
 import { Provider, Widget } from '@tinystacks/ops-model';
 
-export type GithubCredentials = {
+export interface GithubCredentials {
   token: string;
-};
+}
 
-export type GithubCredentialsProvider = Provider & {
+export interface GithubCredentialsProvider extends Provider {
   credentials: GithubCredentials;
   /**
    * The GitHub hostname to target.  Set this for Github Enterprise.
    */
   host?: string;
-};
+}
 
-export type Cli = Widget & {
+export interface Cli extends Widget  {
   command: string
   commandResult?: { stdout: string, stderr: string };
   runOnStart?: boolean
   hasRun?: boolean
   environmentVariables?: { [key: string]: string }
-};
+}
 
-export type GithubAction = {
+export interface GithubAction {
   name: string;
   trigger: string;
   status: string;
   lastExecuted: Date;
   url: string;
-};
+}
 
-export type Github = Widget & {
+export interface Github extends Widget  {
   host?: string;
   organization: string;
   repository: string;
   actions?: GithubAction[];
-};
+}
 
-export type Grid = Widget & { columns?: number };
+export interface Grid extends Widget  { columns?: number }
 
-export type JsonFilter = Widget & {
+export interface JsonFilter extends Widget  {
   jsonObject: { [key: string]: any; },
   paths: {
     pathDisplayName: string,
@@ -47,10 +47,10 @@ export type JsonFilter = Widget & {
     pathDisplayName: string,
     json: any
   }[]
-};
+}
 
-export type Markdown = Widget & { markdown: string };
+export interface Markdown extends Widget  { markdown: string }
 
-export type Panel = Widget & { orientation?: 'horizontal' | 'vertical' };
+export interface Panel extends Widget  { orientation?: 'horizontal' | 'vertical' }
 
-export type Tabs = Widget & { tabNames?: string[] };
+export interface Tabs extends Widget  { tabNames?: string[] }


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Patch

## Link to Notion Task or Github Issue
[Widget docs props representation](https://www.notion.so/tinystacks/Goals-07ccd37a0c9d4bd5bad6fc3dbbe13995)

## Summary of Patch
Change ops-types from `type` to `interface`

## Other details
In order to better represent our types in our [docs](https://github.com/tinystacks/ops-docs) we needed to change them from typescript `type`'s to `interfaces`'s.  This results in something that is slightly heavier pre-build because of more potential inheritance patterns etc., but the output post-build (what we distribute in the package) is nearly identical.

This change is mostly due to limitations of the tooling we are using to generate our documentation.  With the master-build approach we were able to link to the parent type, but with the types as `type`'s it did not generate additional details unless the type was independent.  By switching to interfaces, we always get the rich details view.  See screenshots below for more detail.

## Screenshots

### Generated Docs for Interface
<img width="1463" alt="Screen Shot 2023-06-09 at 9 29 03 AM" src="https://github.com/tinystacks/ops-core-widgets/assets/13314870/9f8602bb-c585-4476-bc3b-b085cb323908">
<img width="1466" alt="Screen Shot 2023-06-09 at 9 29 12 AM" src="https://github.com/tinystacks/ops-core-widgets/assets/13314870/942fd2b4-407e-4b06-a6f4-3cb3fa2a99a9">

### Generated Docs for Independent Type
<img width="1462" alt="Screen Shot 2023-06-09 at 9 33 19 AM" src="https://github.com/tinystacks/ops-core-widgets/assets/13314870/31df02d1-8c90-4359-be9d-4a1cae78437d">

### Generated Docs for Type with Inheritance
<img width="1466" alt="Screen Shot 2023-06-09 at 9 33 34 AM" src="https://github.com/tinystacks/ops-core-widgets/assets/13314870/483f8cf2-d109-4bf6-97ae-038ffbd984ba">

